### PR TITLE
Another IK improvement: guessing correct PalmToThumb vector

### DIFF
--- a/CustomAvatar/VRIK/IKSolverVR.cs
+++ b/CustomAvatar/VRIK/IKSolverVR.cs
@@ -50,7 +50,7 @@ namespace AvatarScriptPack {
 			}
 			
 			if (leftArm.palmToThumbAxis == Vector3.zero || !onlyIfZero) {
-				leftArm.palmToThumbAxis = GuessPalmToThumbAxis(references.leftHand, references.leftForearm);
+				leftArm.palmToThumbAxis = GuessPalmToThumbAxis(references.leftHand, references.leftForearm, leftArm.wristToPalmAxis);
 			}
 			
 			if (rightArm.wristToPalmAxis == Vector3.zero || !onlyIfZero) {
@@ -58,7 +58,7 @@ namespace AvatarScriptPack {
 			}
 			
 			if (rightArm.palmToThumbAxis == Vector3.zero || !onlyIfZero) {
-				rightArm.palmToThumbAxis = GuessPalmToThumbAxis(references.rightHand, references.rightForearm);
+				rightArm.palmToThumbAxis = GuessPalmToThumbAxis(references.rightHand, references.rightForearm, rightArm.wristToPalmAxis);
 			}
 		}
 
@@ -234,7 +234,7 @@ namespace AvatarScriptPack {
 			return axis;
 		}
 
-		private Vector3 GuessPalmToThumbAxis(Transform hand, Transform forearm) {
+		private Vector3 GuessPalmToThumbAxis(Transform hand, Transform forearm, Vector3 wristToPalmAxis) {
 			if (hand.childCount == 0) {
 				Debug.LogWarning("Hand " + hand.name + " does not have any fingers, VRIK can not guess the hand bone's orientation. Please assign 'Wrist To Palm Axis' and 'Palm To Thumb Axis' manually for both arms in VRIK settings.", hand);
 				return Vector3.zero;
@@ -251,9 +251,10 @@ namespace AvatarScriptPack {
 				}
 			}
 
-			Vector3 handNormal = Vector3.Cross(hand.position - forearm.position, hand.GetChild(thumbIndex).position - hand.position);
-			Vector3 toThumb = Vector3.Cross(handNormal, hand.position -forearm.position);
-			Vector3 axis = AxisTools.ToVector3(AxisTools.GetAxisToDirection(hand, toThumb));
+			Vector3 wristToPalm = hand.rotation * wristToPalmAxis;
+			Vector3 handNormal = Vector3.Cross(wristToPalm, (hand.GetChild(thumbIndex).position - hand.position).normalized).normalized;
+			Vector3 toThumb = Vector3.Cross(handNormal, wristToPalm).normalized;
+			Vector3 axis = Quaternion.Inverse(hand.rotation) * toThumb;
 			if (Vector3.Dot(toThumb, hand.rotation * axis) < 0f) axis = -axis;
 			return axis;
 		}

--- a/CustomAvatar/VRIK/IKSolverVRArm.cs
+++ b/CustomAvatar/VRIK/IKSolverVRArm.cs
@@ -416,7 +416,7 @@ namespace AvatarScriptPack {
 				b = chestRotation * b;
 
 				b = Vector3.Slerp(b, armDir, 0.5f);
-				Vector3 vectorHand = (q * wristToPalmAxis * 0.15f + q * palmToThumbAxis * 0.85f) * -1.0f;
+				Vector3 vectorHand = q * Vector3.Slerp(wristToPalmAxis, palmToThumbAxis, 0.85f) * -1.0f;
 				float handWeight = (Vector3.Dot(b, vectorHand) + 1.0f) * 0.5f * 0.75f; // to range of 0 - 0.75
 				b = Vector3.Slerp(b, vectorHand, handWeight);
 


### PR DESCRIPTION
Some avatar (probably A-posed fbx) has about 45degrees of roll on bone gameobject for its hands. This leads VRIK to guess PalmToThumb vector as value with unwanted drift on pitch at maximum of 45degrees. The fix makes VRIK to guess correct vector even if a hand bone gameobject has roll angle.
We have vids for review

Before: https://streamable.com/fu9c9

After: https://streamable.com/4f9a4